### PR TITLE
fix: 修复树复选框可能出现子节点被勾选, 父节点未被勾选的问题 #3

### DIFF
--- a/packages/components/tree/src/tree.vue
+++ b/packages/components/tree/src/tree.vue
@@ -97,7 +97,7 @@ export default defineComponent({
           const checkedChildNodes = root.childNodes.filter((item: Node) => item.checked)
           if (!checkedChildNodes.length) {
             root.checked = false
-            if (root.children.filter((item : Node) => item.indeterminate).length <= 0) {
+            if (root.childNodes.filter((item : Node) => item.indeterminate).length <= 0) {
               root.indeterminate = false
             }
           }


### PR DESCRIPTION
![image](https://github.com/vangleer/vangle/assets/26110382/94c197eb-16d5-4354-961e-171992a8dbb5)
上述结果是这次提交代码后验证的结果。

很抱歉，昨天提交的代码，出现个变量错误。

